### PR TITLE
Use rimraf to clean-up temporary folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### v0.1.1
 
+- Use `rimraf` instead of `rm -rf` (see #41).
+
 - Update Prettier rules (see #40).
 
 - Update CODEBEAT project UUID (see #39).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "karma": "karma start --single-run",
     "autoformat": "prettier --config .prettierrc --write {src,test}/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "clean-up": "rm -rf .nyc_output && rm -rf coverage && rm -rf lib",
+    "clean-up": "rimraf .nyc_output && rimraf coverage && rimraf lib",
     "compile": "tsc -d",
     "dev": "webpack",
     "build": "webpack --env.production",


### PR DESCRIPTION
Use `rimraf` instead of `rm -rf` to clean-up temporary folders.