### PR TITLE
Map payloads into the context of macro commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - Update `karma` setup to generate code coverage report only for `src` folder (see #65).
 
+- Map payloads into the context of macro commands (see #49 and #68).
+
 - Update dev dependencies to latest version.
 
 ### [v0.2.0](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot/releases/tag/0.2.0) - 2018-08-02

--- a/README.md
+++ b/README.md
@@ -300,14 +300,14 @@ mappings will be ignored.
 
 This behaviour does not apply to **parallel commands**.
 
-### Macro Command Triggers
+## Macro Command Triggers
 
 Macro commands can be triggered by **Events** or **Signals**. In both cases, it is common to have to send payloads to the macro command or sub-commands
 through the **Event** or **Signal** trigger.
 
 The macro command can capture the **CommandPayload** provided by the **CommandExecutor** and map it into the context of the sub-commands.
 
-#### Events
+### Events
 
 The **Event** class from `@robotlegsjs/core` package can send parameters through the optional `data` property. In more complex cases, you can create your
 own **CustomEvent** class that extends the **Event** class, adding as many payloads as you wish.
@@ -376,7 +376,7 @@ class NotMuted implements IGuard {
 }
 ```
 
-#### Signals
+### Signals
 
 The **Signal** class from `@robotlegsjs/signals` package can be extended to send parameters through the `dispatch` trigger.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,10 @@ import { inject, injectable } from "@robotlegsjs/core";
 
 import { ParallelMacro } from "@robotlegsjs/macrobot";
 
+import { LoadDataCommand } from "./commands/LoadDataCommand";
+import { LoadSpriteSheetsCommand } from "./commands/LoadSpriteSheetsCommand";
+import { LoadSoundsCommand } from "./commands/LoadSoundsCommand";
+
 @injectable()
 export class LoadAssetsMacro extends ParallelMacro {
     public prepare(): void {
@@ -437,6 +441,10 @@ only when the sound system is not muted:
 import { inject, injectable } from "@robotlegsjs/core";
 
 import { ParallelMacro } from "@robotlegsjs/macrobot";
+
+import { LoadDataCommand } from "./commands/LoadDataCommand";
+import { LoadSpriteSheetsCommand } from "./commands/LoadSpriteSheetsCommand";
+import { LoadSoundsCommand } from "./commands/LoadSoundsCommand";
 
 @injectable()
 export class LoadAssetsMacro extends ParallelMacro {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-RobotlegsJS Macrobot
-===
+# RobotlegsJS Macrobot
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot/blob/master/LICENSE)
 [![Gitter chat](https://badges.gitter.im/RobotlegsJS/RobotlegsJS.svg)](https://gitter.im/RobotlegsJS/RobotlegsJS)
@@ -14,8 +13,7 @@ RobotlegsJS Macrobot
 **Macrobot** is a macro command utility for [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS) which provides the ability to execute batches of commands in sequential or parallel fashion. It was originally implemented by [Alessandro Bianco](https://github.com/alebianco) in [AS3](https://github.com/alebianco/robotlegs-utilities-macrobot) and now is
 ported to [TypeScript](https://www.typescriptlang.org).
 
-Introduction
----
+## Introduction
 
 While using [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS) and encapsulating your business logic inside commands, you may find yourself in a situation where you wish to batch commands, instead of relying on events to trigger every step.
 
@@ -25,13 +23,12 @@ While using [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS) and encaps
 
 - **Parallel**: The commands will be executed as quickly as possible, with no regards to the order in which they were registered. The macro itself will not be complete until all its commands are complete.
 
-Installation
----
+## Installation
 
 You can get the latest release and the type definitions using [NPM](https://www.npmjs.com/):
 
 ```bash
-npm install @robotlegsjs/macrobot
+npm install @robotlegsjs/macrobot --save-prod
 ```
 
 Or using [Yarn](https://yarnpkg.com/en/):
@@ -40,8 +37,7 @@ Or using [Yarn](https://yarnpkg.com/en/):
 yarn add @robotlegsjs/macrobot
 ```
 
-Usage
----
+## Usage
 
 To create a macro command, extend one of the two classes Macrobot provides: `SequenceMacro` or `ParallelMacro`.
 Override the `prepare()` method and add sub commands by calling `add()` specifying the command class to use.
@@ -230,7 +226,8 @@ import { AsyncCommand, SequenceMacro } from "@robotlegsjs/macrobot";
 
 @injectable()
 export class DelayCommand extends AsyncCommand {
-    @inject(Number) protected _delay: number;
+    @inject(Number)
+    protected _delay: number;
 
     public execute(): void {
         setTimeout(this.onTimeout.bind(this), this._delay);
@@ -282,9 +279,11 @@ export class NonAtomicSequenceCommand extends SequenceMacro {
 
 @injectable()
 class DelayAsyncCommand extends AsyncCommand {
-    @inject(Number) protected _delay: number;
+    @inject(Number)
+    protected _delay: number;
 
-    @inject(Boolean) protected _succeed: boolean;
+    @inject(Boolean)
+    protected _succeed: boolean;
 
     public execute(): void {
         setTimeout(this.onTimeout.bind(this), this._delay);
@@ -301,12 +300,173 @@ mappings will be ignored.
 
 This behaviour does not apply to **parallel commands**.
 
-Contributing
----
+### Macro Command Triggers
+
+Macro commands can be triggered by **Events** or **Signals**. In both cases, it is common to have to send payloads to the macro command or sub-commands
+through the **Event** or **Signal** trigger.
+
+The macro command can capture the **CommandPayload** provided by the **CommandExecutor** and map it into the context of the sub-commands.
+
+#### Events
+
+The **Event** class from `@robotlegsjs/core` package can send parameters through the optional `data` property. In more complex cases, you can create your
+own **CustomEvent** class that extends the **Event** class, adding as many payloads as you wish.
+
+When dispatching an event, the **IEventCommandMap** will map the triggered **Event** into the context of the macro command,
+allowing you to access it from inside the macro, from inside guards and hooks or even from inside the context of each sub-command.
+
+Here's an example of a macro command that will load all the assets for your application based on the options of each user.
+In this case, the user can disable the sound system through user options. When loading the assets, you don't need to load the sound files when the **muted** option is enabled.
+
+```typescript
+import { IEventCommandMap, IEventDispatcher } from "@robotlegsjs/core";
+
+import { LoadAssetsMacro } from "./commands/LoadAssetsMacro";
+
+import { AssetsEvent } from "./events/AssetsEvent";
+
+export class LoadAssets {
+    @inject(IEventCommandMap)
+    protected _eventCommandMap: IEventCommandMap;
+
+    @inject(IEventDispatcher)
+    protected _eventDispatcher: IEventDispatcher;
+
+    public loadAssets(): void {
+        this._eventCommandMap.map(AssetsEvent.LOAD_ASSETS, AssetsEvent).toCommand(LoadAssetsMacro);
+
+        let assetsEvent: AssetsEvent = new AssetsEvent(AssetsEvent.LOAD_ASSETS);
+        assetsEvent.muted = false;
+
+        this._eventDispatcher.dispatchEvent(assetsEvent);
+    }
+}
+```
+
+Since the `AssetsEvent` will be mapped into the context of the macro command, you can use it on a `Guard` that can allow the execution of the `LoadSoundsCommand`
+only when the sound system is not muted:
+
+```typescript
+import { injectable } from "@robotlegsjs/core";
+
+import { ParallelMacro } from "@robotlegsjs/macrobot";
+
+@injectable()
+export class LoadAssetsMacro extends ParallelMacro {
+    public prepare(): void {
+        // load data for all users
+        this.add(LoadDataCommand);
+
+        // load sprite sheets for all users
+        this.add(LoadSpriteSheetsCommand);
+
+        // load sounds only for users who enabled sound system
+        this.add(LoadSoundsCommand).withGuards(NotMuted);
+    }
+}
+
+@injectable()
+class NotMuted implements IGuard {
+    @inject(AssetsEvent)
+    protected _assetsEvent: AssetsEvent;
+
+    public approve():boolean {
+        return !_assetsEvent.muted;
+    }
+}
+```
+
+#### Signals
+
+The **Signal** class from `@robotlegsjs/signals` package can be extended to send parameters through the `dispatch` trigger.
+
+When dispatching an signal, the **ISignalCommandMap** from `@robotlegsjs/signalcommandmap` package will map the payloads into the context of the macro command,
+allowing you to access them from inside the macro, from inside guards and hooks or even from inside the context of each sub-command.
+
+Here's an example of a macro command that will load all the assets for your application based on the options of each user.
+In this case, the user can disable the sound system through user options. When loading the assets, you don't need to load the sound files when the **muted** option is enabled.
+
+The `AssetsSignal` extends the `Signal` class adding an `Boolean` as payload:
+
+```typescript
+import { injectable } from "@robotlegsjs/core";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class AssetsSignal extends Signal {
+    constructor() {
+        super(Boolean);
+    }
+}
+```
+
+Then you cam map the `AssetsSignal` to the `LoadAssetsMacro` command using the `ISignalCommandMap` extension:
+
+```typescript
+import { IInjector } from "@robotlegsjs/core";
+
+import { ISignalCommandMap } from "@robotlegsjs/signalcommandmap";
+
+import { LoadAssetsMacro } from "./commands/LoadAssetsMacro";
+
+import { AssetsSignal } from "./signals/AssetsSignal";
+
+export class LoadAssets {
+    @inject(IInjector)
+    protected _injector: IInjector;
+
+    @inject(ISignalCommandMap)
+    protected _signalCommandMap: ISignalCommandMap;
+
+    public loadAssets(): void {
+        this._signalCommandMap.map(AssetsSignal).toCommand(LoadAssetsMacro);
+
+        let assetsSignal: AssetsSignal = this._injector.get(AssetsSignal);
+
+        // dispatch the signal telling the macro command that the muted option is disabled
+        assetsSignal.dispatch(false);
+    }
+}
+```
+
+Since the payload of the `AssetsSignal` will be mapped into the context of the macro command, you can use it on a `Guard` that can allow the execution of the `LoadSoundsCommand`
+only when the sound system is not muted:
+
+```typescript
+import { injectable } from "@robotlegsjs/core";
+
+import { ParallelMacro } from "@robotlegsjs/macrobot";
+
+@injectable()
+export class LoadAssetsMacro extends ParallelMacro {
+    public prepare(): void {
+        // load data for all users
+        this.add(LoadDataCommand);
+
+        // load sprite sheets for all users
+        this.add(LoadSpriteSheetsCommand);
+
+        // load sounds only for users who enabled sound system
+        this.add(LoadSoundsCommand).withGuards(NotMuted);
+    }
+}
+
+@injectable()
+class NotMuted implements IGuard {
+    @inject(Boolean)
+    protected _muted: Boolean;
+
+    public approve():boolean {
+        return !this._muted;
+    }
+}
+```
+
+## Contributing
 
 If you want to contribute to the project refer to the [contributing document](CONTRIBUTING.md) for guidelines.
 
-License
----
+## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ export class AssetsSignal extends Signal {
 }
 ```
 
-Then you cam map the `AssetsSignal` to the `LoadAssetsMacro` command using the `ISignalCommandMap` extension:
+Then you can map the `AssetsSignal` to the `LoadAssetsMacro` command using the `ISignalCommandMap` extension:
 
 ```typescript
 import { inject, IInjector } from "@robotlegsjs/core";

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Here's an example of a macro command that will load all the assets for your appl
 In this case, the user can disable the sound system through user options. When loading the assets, you don't need to load the sound files when the **muted** option is enabled.
 
 ```typescript
-import { IEventCommandMap, IEventDispatcher } from "@robotlegsjs/core";
+import { inject, IEventCommandMap, IEventDispatcher } from "@robotlegsjs/core";
 
 import { LoadAssetsMacro } from "./commands/LoadAssetsMacro";
 
@@ -347,7 +347,7 @@ Since the `AssetsEvent` will be mapped into the context of the macro command, yo
 only when the sound system is not muted:
 
 ```typescript
-import { injectable } from "@robotlegsjs/core";
+import { inject, injectable } from "@robotlegsjs/core";
 
 import { ParallelMacro } from "@robotlegsjs/macrobot";
 
@@ -404,7 +404,7 @@ export class AssetsSignal extends Signal {
 Then you cam map the `AssetsSignal` to the `LoadAssetsMacro` command using the `ISignalCommandMap` extension:
 
 ```typescript
-import { IInjector } from "@robotlegsjs/core";
+import { inject, IInjector } from "@robotlegsjs/core";
 
 import { ISignalCommandMap } from "@robotlegsjs/signalcommandmap";
 
@@ -434,7 +434,7 @@ Since the payload of the `AssetsSignal` will be mapped into the context of the m
 only when the sound system is not muted:
 
 ```typescript
-import { injectable } from "@robotlegsjs/core";
+import { inject, injectable } from "@robotlegsjs/core";
 
 import { ParallelMacro } from "@robotlegsjs/macrobot";
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@robotlegsjs/signalcommandmap": "^0.2.0",
     "@types/bluebird": "^3.5.24",
     "@types/chai": "^4.1.4",
     "@types/mocha": "^5.2.5",

--- a/src/robotlegs/bender/utilities/macrobot/impl/AbstractMacro.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/AbstractMacro.ts
@@ -71,9 +71,7 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
         let payloads: Array<ISubCommandPayload<any>> = mapping.payloads;
         let hasPayloads: boolean = payloads.length > 0;
 
-        if (this._macroPayload.hasPayload()) {
-            this.mapMacroPayload(this._macroPayload);
-        }
+        this.mapMacroPayload(this._macroPayload);
 
         if (hasPayloads) {
             this.mapPayloads(payloads);
@@ -93,9 +91,7 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
             this.unmapPayloads(payloads);
         }
 
-        if (this._macroPayload.hasPayload()) {
-            this.unmapMacroPayload(this._macroPayload);
-        }
+        this.unmapMacroPayload(this._macroPayload);
 
         if (command) {
             let isAsync: boolean = command.constructor.prototype.registerCompleteCallback !== undefined;

--- a/src/robotlegs/bender/utilities/macrobot/impl/AbstractMacro.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/AbstractMacro.ts
@@ -9,6 +9,7 @@ import {
     inject,
     injectable,
     interfaces,
+    CommandPayload,
     ContainerModule,
     IClass,
     ICommand,
@@ -32,6 +33,7 @@ import { SubCommandMappingList } from "./SubCommandMappingList";
 @injectable()
 export abstract class AbstractMacro extends AsyncCommand implements IMacro {
     protected _injector: IInjector;
+    protected _macroPayload: CommandPayload;
     protected _mappings: SubCommandMappingList;
     protected _payloadsModule: ContainerModule;
 
@@ -39,8 +41,8 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
         super(context);
 
         this._injector = injector.createChild();
+        this._macroPayload = new CommandPayload();
         this._mappings = new SubCommandMappingList();
-        this.prepare();
     }
 
     public add(commandClass: IClass<ICommand>): ISubCommandConfigurator {
@@ -55,11 +57,23 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
 
     public abstract prepare(): void;
 
+    protected captureMacroPayload(executeArguments: IArguments): void {
+        let i: number = 0;
+
+        for (i = 0; i < executeArguments.length; i++) {
+            this._macroPayload.addPayload(executeArguments[i], executeArguments[i].constructor);
+        }
+    }
+
     protected executeCommand(mapping: ISubCommandMapping): void {
         let command: ICommand;
         let commandClass: IClass<ICommand> = mapping.commandClass;
         let payloads: Array<ISubCommandPayload<any>> = mapping.payloads;
         let hasPayloads: boolean = payloads.length > 0;
+
+        if (this._macroPayload.hasPayload()) {
+            this.mapMacroPayload(this._macroPayload);
+        }
 
         if (hasPayloads) {
             this.mapPayloads(payloads);
@@ -79,6 +93,10 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
             this.unmapPayloads(payloads);
         }
 
+        if (this._macroPayload.hasPayload()) {
+            this.unmapMacroPayload(this._macroPayload);
+        }
+
         if (command) {
             let isAsync: boolean = command.constructor.prototype.registerCompleteCallback !== undefined;
 
@@ -93,6 +111,20 @@ export abstract class AbstractMacro extends AsyncCommand implements IMacro {
             }
         } else {
             this.commandCompleteHandler(true);
+        }
+    }
+
+    protected mapMacroPayload(payload: CommandPayload): void {
+        let i: number = payload.length;
+        while (i--) {
+            this._injector.bind(payload.classes[i]).toConstantValue(payload.values[i]);
+        }
+    }
+
+    protected unmapMacroPayload(payload: CommandPayload): void {
+        let i: number = payload.length;
+        while (i--) {
+            this._injector.unbind(payload.classes[i]);
         }
     }
 

--- a/src/robotlegs/bender/utilities/macrobot/impl/AsyncCommand.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/AsyncCommand.ts
@@ -24,7 +24,7 @@ export abstract class AsyncCommand implements IAsyncCommand {
         this._listeners.unshift(listener);
     }
 
-    public abstract execute(): void;
+    public abstract execute(...args: any[]): void;
 
     protected dispatchComplete(success: boolean): void {
         this._context.release(this);

--- a/src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro.ts
@@ -11,6 +11,7 @@ import { IMacro } from "../api/IMacro";
 import { ISubCommandMapping } from "../api/ISubCommandMapping";
 
 import { AbstractMacro } from "./AbstractMacro";
+
 @injectable()
 export abstract class ParallelMacro extends AbstractMacro implements IMacro {
     private _executionCount: number = 0;

--- a/src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro.ts
@@ -5,11 +5,13 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
+import { injectable } from "@robotlegsjs/core";
+
 import { IMacro } from "../api/IMacro";
 import { ISubCommandMapping } from "../api/ISubCommandMapping";
 
 import { AbstractMacro } from "./AbstractMacro";
-
+@injectable()
 export abstract class ParallelMacro extends AbstractMacro implements IMacro {
     private _executionCount: number = 0;
 
@@ -18,7 +20,11 @@ export abstract class ParallelMacro extends AbstractMacro implements IMacro {
 
     private _commands: ISubCommandMapping[];
 
-    public execute(): void {
+    public execute(payload?: any, ...payloads: any[]): void {
+        this.captureMacroPayload(arguments);
+
+        this.prepare();
+
         this._commands = this._mappings.getList();
 
         if (this.hasCommands) {

--- a/src/robotlegs/bender/utilities/macrobot/impl/SequenceMacro.ts
+++ b/src/robotlegs/bender/utilities/macrobot/impl/SequenceMacro.ts
@@ -5,11 +5,14 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
+import { injectable } from "@robotlegsjs/core";
+
 import { IMacro } from "../api/IMacro";
 import { ISubCommandMapping } from "../api/ISubCommandMapping";
 
 import { AbstractMacro } from "./AbstractMacro";
 
+@injectable()
 export abstract class SequenceMacro extends AbstractMacro implements IMacro {
     private _executionIndex: number;
 
@@ -32,13 +35,18 @@ export abstract class SequenceMacro extends AbstractMacro implements IMacro {
         }
     }
 
-    public execute(): void {
+    public execute(payload?: any, ...payloads: any[]): void {
+        this.captureMacroPayload(arguments);
+
+        this.prepare();
+
         this._atomic = this.atomic;
         this._success = true;
         this._running = true;
         this._completed = false;
         this._executionIndex = 0;
         this._commands = this._mappings.getList();
+
         this.executeNext();
     }
 

--- a/test/robotlegs/bender/utilities/macrobot/impl/parallelMacro.test.ts
+++ b/test/robotlegs/bender/utilities/macrobot/impl/parallelMacro.test.ts
@@ -23,6 +23,7 @@ import {
 import { TestAddAndRemoveParallelCommand } from "../support/TestAddAndRemoveParallelCommand";
 import { TestParallelCommand } from "../support/TestParallelCommand";
 import { TestParallelWithCompleteCallbackCommand } from "../support/TestParallelWithCompleteCallbackCommand";
+import { TestParallelWithPayloadCommand } from "../support/TestParallelWithPayloadCommand";
 import { TestEmptyParallelCommand } from "../support/TestEmptyParallelCommand";
 
 describe("ParallelMacro", () => {
@@ -128,5 +129,27 @@ describe("ParallelMacro", () => {
             assert.deepEqual(reported, []);
             done();
         }, 50);
+    });
+
+    it("event_is_mapped_in_the_context_of_sub_commands", (done: Function) => {
+        const event: Event = new Event("trigger");
+        event.data = "Event triggered command";
+        eventCommandMap.map("trigger", Event).toCommand(TestParallelWithPayloadCommand);
+        dispatcher.dispatchEvent(event);
+
+        setTimeout(() => {
+            assert.deepEqual(reported, [
+                "Event triggered command: start execution of Command 1 and await 100 milliseconds",
+                "Event triggered command: start execution of Command 2 and await 75 milliseconds",
+                "Event triggered command: start execution of Command 3 and await 50 milliseconds",
+                "Event triggered command: start execution of Command 4 and await 25 milliseconds",
+                "Event triggered command: complete execution of Command 4",
+                "Event triggered command: complete execution of Command 3",
+                "Event triggered command: complete execution of Command 2",
+                "Event triggered command: complete execution of Command 1"
+            ]);
+
+            done();
+        }, 250);
     });
 });

--- a/test/robotlegs/bender/utilities/macrobot/impl/sequenceMacro.test.ts
+++ b/test/robotlegs/bender/utilities/macrobot/impl/sequenceMacro.test.ts
@@ -34,6 +34,7 @@ import { TestSequenceWithHappyGuardsCommand } from "../support/TestSequenceWithH
 import { TestSequenceWithHooksCommand } from "../support/TestSequenceWithHooksCommand";
 import { TestSequenceWithInjectedHooksCommand } from "../support/TestSequenceWithInjectedHooksCommand";
 import { TestSequenceWithNamedPayloadsCommand } from "../support/TestSequenceWithNamedPayloadsCommand";
+import { TestSequenceWithPayloadCommand } from "../support/TestSequenceWithPayloadCommand";
 import { TestSequenceWithPayloadInjectedIntoGuardsCommand } from "../support/TestSequenceWithPayloadInjectedIntoGuardsCommand";
 import { TestSequenceWithPayloadInjectedIntoHooksCommand } from "../support/TestSequenceWithPayloadInjectedIntoHooksCommand";
 import { TestSequenceWithStringPayloadCommand } from "../support/TestSequenceWithStringPayloadCommand";
@@ -250,5 +251,13 @@ describe("SequenceMacro", () => {
 
             done();
         }, 250);
+    });
+
+    it("event_is_mapped_in_the_context_of_sub_commands", () => {
+        const event: Event = new Event("trigger");
+        event.data = "Command:";
+        eventCommandMap.map("trigger", Event).toCommand(TestSequenceWithPayloadCommand);
+        dispatcher.dispatchEvent(event);
+        assert.deepEqual(reported, ["Command:1", "Command:2", "Command:3"]);
     });
 });

--- a/test/robotlegs/bender/utilities/macrobot/impl/signalsMappedToMacro.test.ts
+++ b/test/robotlegs/bender/utilities/macrobot/impl/signalsMappedToMacro.test.ts
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../../entry";
+
+import { assert } from "chai";
+
+import { Signal } from "@robotlegsjs/signals";
+
+import { IContext, IInjector, Context, CommandMapper } from "@robotlegsjs/core";
+
+import { SignalCommandTrigger } from "@robotlegsjs/signalcommandmap";
+
+import { DelaySignal } from "../support/DelaySignal";
+import { ParametersSignal } from "../support/ParametersSignal";
+import { TestParallelBySignalCommand } from "../support/TestParallelBySignalCommand";
+import { TestSequenceBySignalCommand } from "../support/TestSequenceBySignalCommand";
+
+describe("SignalsMappedToMacro", () => {
+    let context: IContext;
+    let injector: IInjector;
+    let signal: Signal;
+    let signalCommandTrigger: SignalCommandTrigger;
+    let mapper: CommandMapper;
+    let reported: any[];
+
+    function reportingFunction(item: any): void {
+        reported.push(item);
+    }
+
+    beforeEach(() => {
+        context = new Context();
+        injector = context.injector;
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("reportingFunction");
+
+        signalCommandTrigger = new SignalCommandTrigger(injector, Signal);
+        context.initialize();
+        reported = [];
+    });
+
+    afterEach(() => {
+        if (context.initialized) {
+            context.destroy();
+        }
+
+        signal.removeAll();
+
+        context = null;
+        injector = null;
+        reported = null;
+        signal = null;
+        signalCommandTrigger = null;
+        mapper = null;
+        reported = null;
+    });
+
+    it("payload_dispatched_by_signal_is_mapped_into_sequence_sub_commands", () => {
+        const expected: any[] = [true, 999, "I'm a string!", Symbol("symbol"), { x: 5, y: 5 }, new Date(), [1, 2, 3, 4, 5, 6, 7, 8, 9]];
+
+        signal = new ParametersSignal();
+        injector.bind(Signal).toConstantValue(signal);
+        mapper = signalCommandTrigger.createMapper();
+        mapper.toCommand(TestSequenceBySignalCommand);
+        signal.dispatch.apply(signal, expected);
+
+        assert.deepEqual(reported, expected.concat(expected));
+    });
+
+    it("payload_dispatched_by_signal_is_mapped_into_parallel_sub_commands", (done: Function) => {
+        signal = new DelaySignal();
+        injector.bind(Signal).toConstantValue(signal);
+        mapper = signalCommandTrigger.createMapper();
+        mapper.toCommand(TestParallelBySignalCommand);
+        signal.dispatch(Symbol("to be ignored"), 50);
+
+        setTimeout(() => {
+            assert.deepEqual(reported, [
+                "Start execution of Command 1 and await 50 milliseconds",
+                "Start execution of Command 2 and await 50 milliseconds",
+                "Start execution of Command 3 and await 50 milliseconds",
+                "Start execution of Command 4 and await 50 milliseconds",
+                "Complete execution of Command 1",
+                "Complete execution of Command 2",
+                "Complete execution of Command 3",
+                "Complete execution of Command 4"
+            ]);
+
+            done();
+        }, 250);
+    });
+});

--- a/test/robotlegs/bender/utilities/macrobot/support/CallbackParametersCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/CallbackParametersCommand.ts
@@ -1,0 +1,73 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named, optional, ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class CallbackParametersCommand implements ICommand {
+    @inject(Boolean)
+    @optional()
+    public booleanValue: boolean;
+
+    @inject(Number)
+    @optional()
+    public numValue: number;
+
+    @inject(String)
+    @optional()
+    public stringValue: string;
+
+    @inject(Symbol)
+    @optional()
+    public symbolValue: symbol;
+
+    @inject(Object)
+    @optional()
+    public objectValue: object;
+
+    @inject(Date)
+    @optional()
+    public dateValue: Date;
+
+    @inject(Array)
+    @optional()
+    public arrayValue: any[];
+
+    @inject("Function")
+    @named("reportingFunction")
+    public reportingFunction: Function;
+
+    public execute(): void {
+        if (this.booleanValue) {
+            this.reportingFunction(this.booleanValue);
+        }
+
+        if (this.numValue) {
+            this.reportingFunction(this.numValue);
+        }
+
+        if (this.stringValue) {
+            this.reportingFunction(this.stringValue);
+        }
+
+        if (this.symbolValue) {
+            this.reportingFunction(this.symbolValue);
+        }
+
+        if (this.objectValue) {
+            this.reportingFunction(this.objectValue);
+        }
+
+        if (this.dateValue) {
+            this.reportingFunction(this.dateValue);
+        }
+
+        if (this.arrayValue) {
+            this.reportingFunction(this.arrayValue);
+        }
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/DelaySignal.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/DelaySignal.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class DelaySignal extends Signal {
+    constructor() {
+        super(Symbol, Number);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/ParametersSignal.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/ParametersSignal.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class ParametersSignal extends Signal {
+    constructor() {
+        super(Boolean, Number, String, Symbol, Object, Date, Array);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/ReportEventCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/ReportEventCommand.ts
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named, ICommand, Event } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportEventCommand implements ICommand {
+    @inject("Function")
+    @named("reportingFunction")
+    protected _report: Function;
+
+    @inject(Event)
+    protected _event: Event;
+
+    @inject(Number)
+    protected _order: number;
+
+    public execute(): void {
+        this._report(this._event.data + this._order);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/ReportEventWithDelayCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/ReportEventWithDelayCommand.ts
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named, optional, Event } from "@robotlegsjs/core";
+
+import { AsyncCommand } from "../../../../../../src/robotlegs/bender/utilities/macrobot/impl/AsyncCommand";
+
+@injectable()
+export class ReportEventWithDelayCommand extends AsyncCommand {
+    @inject("Function")
+    @named("reportingFunction")
+    protected _report: Function;
+
+    @inject(Event)
+    protected _event: Event;
+
+    @inject(String)
+    protected _name: string;
+
+    @inject(Number)
+    protected _delay: number;
+
+    @inject(Boolean)
+    @optional()
+    protected _succeed: boolean;
+
+    public execute(): void {
+        this._succeed = this._succeed === undefined ? true : this._succeed;
+        this._report(this._event.data + ": start execution of " + this._name + " and await " + this._delay + " milliseconds");
+        setTimeout(this.onTimeout.bind(this), this._delay);
+    }
+
+    protected onTimeout(): void {
+        if (this._succeed) {
+            this._report(this._event.data + ": complete execution of " + this._name);
+        } else {
+            this._report(this._event.data + ": execution of " + this._name + " failed!");
+        }
+        this.dispatchComplete(this._succeed);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/TestParallelBySignalCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/TestParallelBySignalCommand.ts
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { ParallelMacro } from "../../../../../../src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro";
+
+import { ReportDelayAsyncCommand } from "./ReportDelayAsyncCommand";
+
+@injectable()
+export class TestParallelBySignalCommand extends ParallelMacro {
+    public prepare(): void {
+        this.add(ReportDelayAsyncCommand).withPayloads("Command 1");
+        this.add(ReportDelayAsyncCommand).withPayloads("Command 2");
+        this.add(ReportDelayAsyncCommand).withPayloads("Command 3");
+        this.add(ReportDelayAsyncCommand).withPayloads("Command 4");
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/TestParallelWithPayloadCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/TestParallelWithPayloadCommand.ts
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { ParallelMacro } from "../../../../../../src/robotlegs/bender/utilities/macrobot/impl/ParallelMacro";
+
+import { ReportEventWithDelayCommand } from "./ReportEventWithDelayCommand";
+
+@injectable()
+export class TestParallelWithPayloadCommand extends ParallelMacro {
+    public prepare(): void {
+        this.add(ReportEventWithDelayCommand).withPayloads("Command 1", 100);
+        this.add(ReportEventWithDelayCommand).withPayloads("Command 2", 75);
+        this.add(ReportEventWithDelayCommand).withPayloads("Command 3", 50);
+        this.add(ReportEventWithDelayCommand).withPayloads("Command 4", 25);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/TestSequenceBySignalCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/TestSequenceBySignalCommand.ts
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { SequenceMacro } from "../../../../../../src/robotlegs/bender/utilities/macrobot/impl/SequenceMacro";
+import { CallbackParametersCommand } from "./CallbackParametersCommand";
+
+@injectable()
+export class TestSequenceBySignalCommand extends SequenceMacro {
+    public prepare(): void {
+        this.add(CallbackParametersCommand);
+        this.add(CallbackParametersCommand);
+    }
+}

--- a/test/robotlegs/bender/utilities/macrobot/support/TestSequenceWithPayloadCommand.ts
+++ b/test/robotlegs/bender/utilities/macrobot/support/TestSequenceWithPayloadCommand.ts
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Copyright (c) 2017-present, RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "@robotlegsjs/core";
+
+import { SequenceMacro } from "../../../../../../src/robotlegs/bender/utilities/macrobot/impl/SequenceMacro";
+
+import { ReportEventCommand } from "./ReportEventCommand";
+
+@injectable()
+export class TestSequenceWithPayloadCommand extends SequenceMacro {
+    public prepare(): void {
+        this.add(ReportEventCommand).withPayloads(1);
+        this.add(ReportEventCommand).withPayloads(2);
+        this.add(ReportEventCommand).withPayloads(3);
+    }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/tslint.test.json
+++ b/tslint.test.json
@@ -3,7 +3,7 @@
     "./tslint.json"
   ],
   "rules": {
-    "no-implicit-dependencies": [true, "dev"],
+    "no-implicit-dependencies": false,
     "no-submodule-imports": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,11 +177,24 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
 
-"@robotlegsjs/core@^0.2.1":
+"@robotlegsjs/core@^0.2.0", "@robotlegsjs/core@^0.2.1":
   version "0.2.1"
   resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-0.2.1.tgz#4a77f0b85e67343866c44772387617470b67f6c3"
   dependencies:
     inversify "^4.13.0"
+    tslib "^1.9.3"
+
+"@robotlegsjs/signalcommandmap@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@robotlegsjs/signalcommandmap/-/signalcommandmap-0.2.0.tgz#45a8a9cf81afa12bfad2287a664c8598fa09f94e"
+  dependencies:
+    "@robotlegsjs/core" "^0.2.0"
+    "@robotlegsjs/signals" "^0.2.0"
+
+"@robotlegsjs/signals@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@robotlegsjs/signals/-/signals-0.2.0.tgz#a3f272ccd8bdb91771f3ac0fef9c997e2c0ebc8a"
+  dependencies:
     tslib "^1.9.3"
 
 "@sinonjs/formatio@3.0.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,8 +1203,8 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3:
     fsevents "^1.2.2"
 
 chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
 chrome-trace-event@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The `AbstractMacro` class is not mapping the `CommandPayload` into the context of the sub-commands, preventing the customization of the macro command by itself, of **Guards**, of **Hooks** or even of the sub-commands based on the payloads.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#49 Constructor call to prepare() prevents injection in concrete macros.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The `AbstractMacro` was receiving the `CommandPayload` but not mapping it into the context of the sub-commands.

Now the macro is capturing the `CommandPayload` and mapping it, so the payload sent from the trigger can be used inside the macro command, inside guards and hooks and even inside each sub-command.

Also, the `prepare` method is being called outside the `constructor`, allowing the usage of the payloads inside the `prepare` method by itself.

## How Has This Been Tested?

New test cases were added to ensure that the payload of **Events** and **Signals** is mapped into the context of the sub-commands.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
