### PR TITLE
Update @robotlegsjs/signalcommandmap to the latest version 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
-    "@robotlegsjs/signalcommandmap": "^1.0.1",
+    "@robotlegsjs/signalcommandmap": "^1.0.2",
     "@types/bluebird": "^3.5.28",
     "@types/chai": "^4.2.4",
     "@types/mocha": "^5.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,7 @@
   resolved "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz#944d15b3ebdb71f963a628daffaa25ade981bb86"
   integrity sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==
 
-"@robotlegsjs/core@^1.0.1", "@robotlegsjs/core@^1.0.3":
+"@robotlegsjs/core@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-1.0.3.tgz#3ae018b4e8834552a076caf4f4eed7fe1433951a"
   integrity sha512-fWQWvEqCx9SojQsIMbd1thvylhiUqyX11CBlnUJrpRxZEoLIWZ+F71E/7D662en79HGxtb8OAZZR7WXaiixljw==
@@ -109,15 +109,15 @@
     inversify "^5.0.1"
     tslib "^1.10.0"
 
-"@robotlegsjs/signalcommandmap@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@robotlegsjs/signalcommandmap/-/signalcommandmap-1.0.1.tgz#e961f8d74c827c24d58874827546f1088307a4dc"
-  integrity sha512-uKHMHExQARMkfUKImgAuTycljsuOwqhZ0mlSqNNz3z+kHmBi9JR1iI2D2HqYr2zhGQuwthW7WR/BE953IXESuQ==
+"@robotlegsjs/signalcommandmap@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@robotlegsjs/signalcommandmap/-/signalcommandmap-1.0.2.tgz#27c51e54366862d9a44cd38c808a7bc6465072b3"
+  integrity sha512-sKikLAmudDvRtbVU21g8NuFDaDy0uiFL/m2q3XNrMgxQLzJal36EaN/ejto60RXZGa0WQ+2DMP2xZm0ZcvzRzw==
   dependencies:
-    "@robotlegsjs/core" "^1.0.1"
-    "@robotlegsjs/signals" "^1.0.1"
+    "@robotlegsjs/core" "^1.0.3"
+    "@robotlegsjs/signals" "^1.0.3"
 
-"@robotlegsjs/signals@^1.0.1":
+"@robotlegsjs/signals@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@robotlegsjs/signals/-/signals-1.0.3.tgz#c7dc75a0230b277ffefd53363912ca0cd2f01bbf"
   integrity sha512-TMN+vX+jceyTSieYK3VesXTZ8jEQTRQeNSwC108V4B9P6wiVCXOWtLW63+IpaizLSFMwlmmDXM6C6Fte7d/teQ==


### PR DESCRIPTION
The dependency [@robotlegsjs/signalcommandmap](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap) was updated from `1.0.1` to `1.0.2`.